### PR TITLE
Docs: fix copy/paste error

### DIFF
--- a/website/docs/r/vrack_publiccloud_attachment.html.markdown
+++ b/website/docs/r/vrack_publiccloud_attachment.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
     environment variable is used.
 
 * `project_id` - (Required) The id of the public cloud project. If omitted,
-    the `OVH_VRACK_ID` environment variable is used.
+    the `OVH_PROJECT_ID` environment variable is used.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`vrack_publiccloud_attachment`'s `project_id` defaults to `OVH_PROJECT_ID`, not `OVH_VRACK_ID`.