### PR TITLE
Vps resource

### DIFF
--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -91,6 +91,7 @@ func Provider() terraform.ResourceProvider {
 			"ovh_vrack_cloudproject":                                      resourceVrackCloudProject(),
 			"ovh_vrack_dedicated_server":                                  resourceVrackDedicatedServer(),
 			"ovh_vrack_dedicated_server_interface":                        resourceVrackDedicatedServerInterface(),
+			"ovh_vps":                                                     resourceOVHVPS(),
 
 			// Legacy naming schema (publiccloud)
 			"ovh_publiccloud_private_network": deprecated(resourcePublicCloudPrivateNetwork(),

--- a/ovh/resource_ovh_vps.go
+++ b/ovh/resource_ovh_vps.go
@@ -247,7 +247,7 @@ func resourceOVHVPSUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Unknown wanted state")
 		}
 		err := provider.OVHClient.Post(
-			fmt.Sprintf("/vos/%s/%s", d.Id(), command),
+			fmt.Sprintf("/vps/%s/%s", d.Id(), command),
 			nil,
 			nil,
 		)

--- a/ovh/resource_ovh_vps.go
+++ b/ovh/resource_ovh_vps.go
@@ -272,6 +272,7 @@ func OVHVPS_getType(offertype string, model_name string, model_version string) s
 	offertypeToOfferPrefix["cloud"] = "ceph-nvme"
 	offertypeToOfferPrefix["cloud-ram"] = "ceph-nvme-ram"
 	offertypeToOfferPrefix["ssd"] = "ssd"
+	offertypeToOfferPrefix["classic"] = "classic"
 	return (fmt.Sprintf("vps_%s_%s_%s", offertypeToOfferPrefix[offertype],
 		model_name,
 		model_version))

--- a/ovh/resource_ovh_vps.go
+++ b/ovh/resource_ovh_vps.go
@@ -55,10 +55,6 @@ func resourceOVHVPS() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -177,8 +173,7 @@ func resourceOVHVPSRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("id", vps.Name)
-	d.Set("id", vps.Name)
+	d.SetId(vps.Name)
 	d.Set("zone", vps.Zone)
 	d.Set("state", vps.State)
 	d.Set("vcore", vps.Vcore)
@@ -194,7 +189,7 @@ func resourceOVHVPSRead(d *schema.ResourceData, meta interface{}) error {
 	model["offer"] = vps.Model.Offer
 	model["version"] = vps.Model.Version
 	d.Set("model", model)
-	d.Set("type", OVHVPS_getType(vps.OfferType, vps.Model.Name, vps.Model.Version))
+	d.Set("type", ovhvps_getType(vps.OfferType, vps.Model.Name, vps.Model.Version))
 
 	ips := []string{}
 	err = provider.OVHClient.Get(
@@ -267,7 +262,7 @@ func resourceOVHVPSDelete(d *schema.ResourceData, meta interface{}) error {
 	return fmt.Errorf("Deletion is not supported at the moment, please terminate manually and terraform state rm")
 }
 
-func OVHVPS_getType(offertype string, model_name string, model_version string) string {
+func ovhvps_getType(offertype string, model_name string, model_version string) string {
 	var offertypeToOfferPrefix = make(map[string]string)
 	offertypeToOfferPrefix["cloud"] = "ceph-nvme"
 	offertypeToOfferPrefix["cloud-ram"] = "ceph-nvme-ram"

--- a/ovh/resource_ovh_vps.go
+++ b/ovh/resource_ovh_vps.go
@@ -1,0 +1,282 @@
+package ovh
+
+import (
+	"fmt"
+	//	"log"
+	//	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type VPSModel struct {
+	Name    string `json:"name"`
+	Offer   string `json:"offer"`
+	Memory  int    `json:"memory"`
+	Vcore   int    `json:"vcore"`
+	Version string `json:"version"`
+	Disk    int    `json:"disk"`
+}
+
+type VPS struct {
+	Name           string   `json:"name"`
+	Cluster        string   `json:"cluster"`
+	Memory         int      `json:"memoryLimit"`
+	NetbootMode    string   `json:"netbootMode"`
+	Keymap         string   `json:"keymap"`
+	Zone           string   `json:"zone"`
+	State          string   `json:"state"`
+	Vcore          int      `json:"vcore"`
+	OfferType      string   `json:"offerType"`
+	SlaMonitorting bool     `json:"slaMonitoring"`
+	DisplayName    string   `json:"displayName"`
+	Model          VPSModel `json:"model"`
+}
+
+type VPSDatacenter struct {
+	Name     string `json:"name"`
+	Longname string `json:"longname"`
+}
+
+type VPSProperties struct {
+	NetbootMode    *string `json:"netbootMode"`
+	Keymap         *string `json:"keymap"`
+	SlaMonitorting bool    `json:"slaMonitoring"`
+	DisplayName    *string `json:"displayName"`
+}
+
+func resourceOVHVPS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOVHVPSCreate,
+		Read:   resourceOVHVPSRead,
+		Update: resourceOVHVPSUpdate,
+		Delete: resourceOVHVPSDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "running",
+			},
+			"displayname": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"netbootmode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "local",
+			},
+			"slamonitoring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"keymap": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			// Here come all the computed items
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vcore": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"offertype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"model": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"offer": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"ips": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"datacenter": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"longname": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceOVHVPSCreate(d *schema.ResourceData, meta interface{}) error {
+	return fmt.Errorf("Creation is not supported at the moment, please use import")
+}
+
+func resourceOVHVPSRead(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+	vps := VPS{}
+	err := provider.OVHClient.Get(
+		fmt.Sprintf("/vps/%s", d.Id()),
+		&vps,
+	)
+
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("id", vps.Name)
+	d.Set("id", vps.Name)
+	d.Set("zone", vps.Zone)
+	d.Set("state", vps.State)
+	d.Set("vcore", vps.Vcore)
+	d.Set("cluster", vps.Cluster)
+	d.Set("memory", vps.Memory)
+	d.Set("netbootmode", vps.NetbootMode)
+	d.Set("keymap", vps.Keymap)
+	d.Set("offertype", vps.OfferType)
+	d.Set("slamonitoring", vps.SlaMonitorting)
+	d.Set("displayname", vps.DisplayName)
+	var model = make(map[string]string)
+	model["name"] = vps.Model.Name
+	model["offer"] = vps.Model.Offer
+	model["version"] = vps.Model.Version
+	d.Set("model", model)
+	d.Set("type", OVHVPS_getType(vps.OfferType, vps.Model.Name, vps.Model.Version))
+
+	ips := []string{}
+	err = provider.OVHClient.Get(
+		fmt.Sprintf("/vps/%s/ips", d.Id()),
+		&ips,
+	)
+
+	d.Set("ips", ips)
+
+	vpsDatacenter := VPSDatacenter{}
+	err = provider.OVHClient.Get(
+		fmt.Sprintf("/vps/%s/datacenter", d.Id()),
+		&vpsDatacenter,
+	)
+	datacenter := make(map[string]string)
+	datacenter["name"] = vpsDatacenter.Name
+	datacenter["longname"] = vpsDatacenter.Longname
+	d.Set("datacenter", datacenter)
+	return nil
+}
+
+func resourceOVHVPSUpdate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+	const Null = "\xff"
+	if d.HasChange("type") {
+		return fmt.Errorf("Type modification is not supported at the moment")
+	}
+	if d.HasChange("keymap") || d.HasChange("displayname") || d.HasChange("netbootmode") || d.HasChange("slamonitoring") {
+		newProperties := &VPSProperties{
+			Keymap:         strPtr(d.Get("keymap").(string)),
+			DisplayName:    strPtr(d.Get("displayname").(string)),
+			NetbootMode:    strPtr(d.Get("netbootmode").(string)),
+			SlaMonitorting: d.Get("slamonitoring").(bool),
+		}
+		if *newProperties.Keymap == "" {
+			newProperties.Keymap = nil
+		}
+		err := provider.OVHClient.Put(
+			fmt.Sprintf("/vps/%s", d.Id()),
+			newProperties,
+			nil,
+		)
+		if err != nil {
+			return fmt.Errorf("Failed to update VPS: %s", err)
+		}
+	}
+	if d.HasChange("state") {
+		command := ""
+		switch d.Get("state") {
+		case "running":
+			command = "start"
+		case "stopped":
+			command = "stop"
+		default:
+			return fmt.Errorf("Unknown wanted state")
+		}
+		err := provider.OVHClient.Post(
+			fmt.Sprintf("/vos/%s/%s", d.Id(), command),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return fmt.Errorf("Failed to update VPS: %s", err)
+		}
+	}
+	return nil
+}
+
+func resourceOVHVPSDelete(d *schema.ResourceData, meta interface{}) error {
+	return fmt.Errorf("Deletion is not supported at the moment, please terminate manually and terraform state rm")
+}
+
+func OVHVPS_getType(offertype string, model_name string, model_version string) string {
+	var offertypeToOfferPrefix = make(map[string]string)
+	offertypeToOfferPrefix["cloud"] = "ceph-nvme"
+	offertypeToOfferPrefix["cloud-ram"] = "ceph-nvme-ram"
+	offertypeToOfferPrefix["ssd"] = "ssd"
+	return (fmt.Sprintf("vps_%s_%s_%s", offertypeToOfferPrefix[offertype],
+		model_name,
+		model_version))
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/ovh/resource_ovh_vps_test.go
+++ b/ovh/resource_ovh_vps_test.go
@@ -1,0 +1,58 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOVHVps_importBasic(t *testing.T) {
+	resourceName := "ovh_vps.bar"
+	vps_id := os.Getenv("OVH_VPS_ID")
+	vps_type := os.Getenv("OVH_VPS_TYPE")
+	vps_displayname := os.Getenv("OVH_VPS_DISPLAYNAME")
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) == 1 {
+			id := s[0].ID
+			attr := s[0].Attributes
+			if id == vps_id && attr["displayname"] == vps_displayname && attr["type"] == vps_type {
+				return nil
+			}
+		}
+		return fmt.Errorf("Bad content: %#v", s[0])
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOVHDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccOVHVpsConfig,
+				ExpectError: regexp.MustCompile(`use import`),
+			},
+
+			resource.TestStep{
+				Config:           fmt.Sprintf(testAccOVHVpsConfig, vps_type, vps_displayname),
+				ResourceName:     resourceName,
+				ImportStateId:    vps_id,
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+func testAccCheckOVHDestroy(s *terraform.State) error {
+	return nil
+}
+
+const testAccOVHVpsConfig = `
+resource ovh_vps bar {
+  type = "%s"
+  displayname= "%s"
+}
+`

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -97,4 +97,10 @@ You will also need to [generate an OVH token](https://api.ovh.com/createToken/?G
 
  * `OVH_CONSUMER_KEY`
 
+* `OVH_VPS_ID` - The vps id to import (vps-xxxx)
+
+* `OVH_VPS_DISPLAYNAME` - The display name of the imported vps
+
+* `OVH_VPS_TYPE` - The type of the imported vps
+
 You should be able to use any OVH environment to develop on as long as the above environment variables are set.

--- a/website/docs/r/vps.html.markdown
+++ b/website/docs/r/vps.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "ovh"
+page_title: "OVH: ovh_vps"
+sidebar_current: "docs-ovh-resource-vps"
+description: |-
+  Provides a OVH vps resource 
+---
+
+# ovh\_vps
+
+Provides a OVH vps resource
+
+## Example Usage
+
+```hcl
+# Add a vps resource
+resoure ovh_vps test {
+    type = vps_ssd_model1_2018v3
+    displayname = "test"
+    keymap = "us"
+    slamonitoring: false
+    netbootmode: "rescue"
+}
+```
+
+## Argument Reference
+
+The following attributes are supported:
+
+* `type` - (Required) A valid ovh vps type.
+* `displayname` - (Required) The displayed name in the ovh web admin
+* `keymap` - The keymap for the ip kvm, valid values "", "fr", "us", default to ""
+* `slamonitoring` - A boolean to activate OVH sla monitoring, default to `true`
+* `netbootmode` - The source of the boot kernel, either `local` or `rescue`. Default to `local`
+* `state` - The state of the vps ("running", "stopped", "terminating") 
+
+## Attribute Reference
+
+* `cluster` - The ovh cluster the vps is in
+* `datacenter` - The datacenter in which the vps is located
+  * `datacenter.longname` - The fullname of the datacenter (ex: "Strasbourg SBG1")
+  * `datacenter.name` - The short name of the datacenter (ex: "sbg1)
+* `displayname` - The displayed name in the ovh web admin
+* `id` - The vps name (ex: "vps-123456.ovh.net")
+* `ips` - The list of IPs addresses attached to the vps
+* `keymap` - The keymap for the ip kvm, valid values "", "fr", "us"
+* `memory` - The amount of memory in MB of the vps. 
+* `model` - A dict describing the type of vps.
+* `model.name` - The model name (ex: model1)
+* `model.offer` - The model human description (ex: "VPS 2016 SSD 1")
+* `model.version` - The model version (ex: "2017v2")
+* `netbootmode` - The source of the boot kernel
+* `offertype` - The type of offer (ssd, cloud, classic)
+* `slamonitoring` - A boolean to indicate if OVH sla monitoring is active.
+* `state` -  The state of the vps
+* `type` - The type of server
+* `vcore` - The number of vcore of the vps
+* `zone` - The OVH zone where the vps is


### PR DESCRIPTION
This PR create a first implentation of the vps resource for terraform.
At the moment creation is not supported, only importing. Basic modification is possible.
Only import is tested at the moment, due to the lack of creation support and the fact I don't know how to persist a state from an imported resource in a TestStep to another.

Ideas for creation:
* Create a data source for CreditCard Payment Mean to ensure we can do the order
* Create a data source for vps model type

Ideas for deletion:
* A two step deletion:
  1. Use state=terminating to issue the `POST /vps/{serviceName}/terminate`
  2. Pass a var with the received code to issue `POST /vps/{serviceName}/confirmTermination`
* Considered it deleted after a `POST /vps/{serviceName}/terminate`