### PR TITLE
add import to dns zone record

### DIFF
--- a/ovh/resource_ovh_domain_zone_record.go
+++ b/ovh/resource_ovh_domain_zone_record.go
@@ -23,6 +23,9 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 		Read:   resourceOvhDomainZoneRecordRead,
 		Update: resourceOvhDomainZoneRecordUpdate,
 		Delete: resourceOvhDomainZoneRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"zone": {


### PR DESCRIPTION
Zone records are not importable at the moment and it makes importing a new zone a tedious process. This PR aims at doing basing import 