### PR TITLE
Use zone in ID to get import working and write doc

### DIFF
--- a/ovh/resource_ovh_domain_zone_record.go
+++ b/ovh/resource_ovh_domain_zone_record.go
@@ -18,7 +18,7 @@ type OvhDomainZoneRecord struct {
 	SubDomain string `json:"subDomain,omitempty"`
 }
 
-func resourceOvhDomainZoneImportState(
+func resourceOvhDomainZoneRecordImportState(
 	d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
 	givenId := d.Id()
@@ -40,7 +40,7 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 		Update: resourceOvhDomainZoneRecordUpdate,
 		Delete: resourceOvhDomainZoneRecordDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceOvhDomainZoneImportState,
+			State: resourceOvhDomainZoneRecordImportState,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/ovh/resource_ovh_domain_zone_record.go
+++ b/ovh/resource_ovh_domain_zone_record.go
@@ -2,7 +2,6 @@ package ovh
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strconv"
@@ -107,9 +106,6 @@ func resourceOvhDomainZoneRecordRead(d *schema.ResourceData, meta interface{}) e
 	provider := meta.(*Config)
 
 	record := OvhDomainZoneRecord{}
-	if logging.IsDebugOrHigher() {
-		log.Printf("[DEBUG] OVH Get Record ID: %s in zone %s", d.Id(), d.Get("zone").(string))
-	}
 	err := provider.OVHClient.Get(
 		fmt.Sprintf("/domain/zone/%s/record/%s", d.Get("zone").(string), d.Id()),
 		&record,

--- a/website/docs/r/ovh_domain_zone_record.html.markdown
+++ b/website/docs/r/ovh_domain_zone_record.html.markdown
@@ -45,3 +45,10 @@ The following attributes are exported:
 * `fieldType` - The type of the record
 * `ttl` - The TTL of the record
 
+## Import
+
+OVH record can be imported using the `id` and the `zone`, eg:
+
+```
+$ terraform import aws_domain_zone_record.test 1234OVH_ID.zone.tld
+```

--- a/website/docs/r/ovh_domain_zone_record.html.markdown
+++ b/website/docs/r/ovh_domain_zone_record.html.markdown
@@ -50,5 +50,5 @@ The following attributes are exported:
 OVH record can be imported using the `id` and the `zone`, eg:
 
 ```
-$ terraform import aws_domain_zone_record.test 1234OVH_ID.zone.tld
+$ terraform import ovh_domain_zone_record.test 1234OVH_ID.zone.tld
 ```


### PR DESCRIPTION
Previsous PR was not working due to the fact that id without zone do not define a record. This PR works this around by importing using OVH_ID.zone format as explained in the updated documentation