### PR TITLE
provider: Make homedir detection more robust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-providers/terraform-provider-ovh
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.0.0-20190227065421-fc531f54a878
+	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
 	github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014
 	gopkg.in/ini.v1 v1.42.0
 )


### PR DESCRIPTION
This PR building on top of #10 and uses `go-homedir` which has more robust mechanism (which doesn't _just_ rely on `os/user` & single ENV variable) to detect user's home directory across platforms.