### PR TITLE
ovh_domain_zone_record: Make fieldtype non-updatable

### DIFF
--- a/ovh/resource_ovh_domain_zone_record.go
+++ b/ovh/resource_ovh_domain_zone_record.go
@@ -75,6 +75,7 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 			"fieldtype": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"subdomain": {
 				Type:     schema.TypeString,

--- a/ovh/resource_ovh_domain_zone_record_test.go
+++ b/ovh/resource_ovh_domain_zone_record_test.go
@@ -103,7 +103,7 @@ func TestAccOvhDomainZoneRecord_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckOvhDomainZoneRecordConfig_basic, zone, subdomain),
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.10", 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
 					resource.TestCheckResourceAttr(
@@ -131,7 +131,7 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCheckOvhDomainZoneRecordConfig_basic, zone, subdomain),
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.10", 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
 					resource.TestCheckResourceAttr(
@@ -145,7 +145,7 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckOvhDomainZoneRecordConfig_new_value_1, zone, subdomain),
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.11", 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
 					resource.TestCheckResourceAttr(
@@ -159,7 +159,8 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckOvhDomainZoneRecordConfig_new_value_2, zone, subdomain),
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, fmt.Sprintf("%s2", subdomain),
+					"192.168.0.11", 3600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
 					resource.TestCheckResourceAttr(
@@ -173,7 +174,8 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckOvhDomainZoneRecordConfig_new_value_3, zone, subdomain),
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, fmt.Sprintf("%s3", subdomain),
+					"192.168.0.13", 3604),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
 					resource.TestCheckResourceAttr(
@@ -245,38 +247,13 @@ func testAccCheckOvhDomainZoneRecordExists(n string, record *OvhDomainZoneRecord
 	}
 }
 
-const testAccCheckOvhDomainZoneRecordConfig_basic = `
+func testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, target string, ttl int) string {
+	return fmt.Sprintf(`
 resource "ovh_domain_zone_record" "foobar" {
 	zone = "%s"
 	subdomain = "%s"
-	target = "192.168.0.10"
+	target = "%s"
 	fieldtype = "A"
-	ttl = 3600
-}`
-
-const testAccCheckOvhDomainZoneRecordConfig_new_value_1 = `
-resource "ovh_domain_zone_record" "foobar" {
-	zone = "%s"
-	subdomain = "%s"
-	target = "192.168.0.11"
-	fieldtype = "A"
-	ttl = 3600
+	ttl = %d
+}`, zone, subdomain, target, ttl)
 }
-`
-const testAccCheckOvhDomainZoneRecordConfig_new_value_2 = `
-resource "ovh_domain_zone_record" "foobar" {
-	zone = "%s"
-	subdomain = "%s2"
-	target = "192.168.0.11"
-	fieldtype = "A"
-	ttl = 3600
-}
-`
-const testAccCheckOvhDomainZoneRecordConfig_new_value_3 = `
-resource "ovh_domain_zone_record" "foobar" {
-	zone = "%s"
-	subdomain = "%s3"
-	target = "192.168.0.13"
-	fieldtype = "A"
-	ttl = 3604
-}`

--- a/ovh/resource_ovh_domain_zone_record_test.go
+++ b/ovh/resource_ovh_domain_zone_record_test.go
@@ -192,6 +192,52 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 	})
 }
 
+func TestAccOvhDomainZoneRecord_updateType(t *testing.T) {
+	record := OvhDomainZoneRecord{}
+	zone := os.Getenv("OVH_ZONE")
+	subdomain := acctest.RandomWithPrefix(test_prefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.1", 3600),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "subdomain", subdomain),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "target", "192.168.0.1"),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "fieldtype", "A"),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "ttl", "3600"),
+				),
+			},
+			{
+				Config: testAccCheckOvhDomainZoneRecordConfig_CNAME(zone, subdomain, "google.com.", 3600),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvhDomainZoneRecordExists("ovh_domain_zone_record.foobar", &record),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "subdomain", subdomain),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "zone", zone),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "target", "google.com."),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "fieldtype", "CNAME"),
+					resource.TestCheckResourceAttr(
+						"ovh_domain_zone_record.foobar", "ttl", "3600"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckOvhDomainZoneRecordDestroy(s *terraform.State) error {
 	provider := testAccProvider.Meta().(*Config)
 	zone := os.Getenv("OVH_ZONE")
@@ -254,6 +300,17 @@ resource "ovh_domain_zone_record" "foobar" {
 	subdomain = "%s"
 	target = "%s"
 	fieldtype = "A"
+	ttl = %d
+}`, zone, subdomain, target, ttl)
+}
+
+func testAccCheckOvhDomainZoneRecordConfig_CNAME(zone, subdomain, target string, ttl int) string {
+	return fmt.Sprintf(`
+resource "ovh_domain_zone_record" "foobar" {
+	zone = "%s"
+	subdomain = "%s"
+	target = "%s"
+	fieldtype = "CNAME"
 	ttl = %d
 }`, zone, subdomain, target, ttl)
 }


### PR DESCRIPTION
Tests without patch:

```
make testacc TEST=./ovh TESTARGS='-run=TestAccOvhDomainZoneRecord_updateType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovh -v -run=TestAccOvhDomainZoneRecord_updateType -timeout 120m
=== RUN   TestAccOvhDomainZoneRecord_updateType
--- FAIL: TestAccOvhDomainZoneRecord_updateType (12.17s)
    testing.go:538: Step 1 error: Error applying: 1 error(s) occurred:

        * ovh_domain_zone_record.foobar: 1 error(s) occurred:

        * ovh_domain_zone_record.foobar: Failed to update OVH Record: Error 400: "Try to alter read-only properties: fieldType"
FAIL
FAIL	github.com/terraform-providers/terraform-provider-ovh/ovh	12.194s
make: *** [testacc] Error 1
```

with patch:

```
make testacc TEST=./ovh TESTARGS='-run=TestAccOvhDomainZoneRecord_updateType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovh -v -run=TestAccOvhDomainZoneRecord_updateType -timeout 120m
=== RUN   TestAccOvhDomainZoneRecord_updateType
--- PASS: TestAccOvhDomainZoneRecord_updateType (12.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ovh/ovh	12.167s
```