### PR TITLE
Split PreCheck for acceptance tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
@@ -127,6 +128,7 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/ovh/data_source_ovh_domain_zone_test.go
+++ b/ovh/data_source_ovh_domain_zone_test.go
@@ -15,7 +15,7 @@ func TestAccDomainZoneDataSource_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccDomainZoneDatasourceConfig_Basic, zoneName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccCheckDomainZoneExists(t) },
+		PreCheck:  func() { testAccPreCheckDomain(t); testAccCheckDomainZoneExists(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/data_source_ovh_iploadbalancing_test.go
+++ b/ovh/data_source_ovh_iploadbalancing_test.go
@@ -13,7 +13,7 @@ func TestAccIpLoadbalancingDataSource_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccIpLoadbalancingDatasourceConfig_Basic, serviceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIpLoadbalancing(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -34,7 +34,7 @@ func TestAccIpLoadbalancingDataSource_statevrack(t *testing.T) {
 	config := fmt.Sprintf(testAccIpLoadbalancingDatasourceConfig_StateAndVrack, serviceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIpLoadbalancing(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/data_source_ovh_me_paymentmean_bankaccount_test.go
+++ b/ovh/data_source_ovh_me_paymentmean_bankaccount_test.go
@@ -14,7 +14,7 @@ func TestAccMePaymentmeanBankaccountDataSource_basic(t *testing.T) {
 	v := os.Getenv("OVH_TEST_BANKACCOUNT")
 	if v == "1" {
 		resource.Test(t, resource.TestCase{
-			PreCheck:  func() { testAccPreCheck(t) },
+			PreCheck:  func() { testAccPreCheckMePaymentMean(t) },
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/ovh/data_source_ovh_me_paymentmean_creditcard_test.go
+++ b/ovh/data_source_ovh_me_paymentmean_creditcard_test.go
@@ -14,7 +14,7 @@ func TestAccMePaymentmeanCreditcardDataSource_basic(t *testing.T) {
 	v := os.Getenv("OVH_TEST_CREDITCARD")
 	if v == "1" {
 		resource.Test(t, resource.TestCase{
-			PreCheck:  func() { testAccPreCheck(t) },
+			PreCheck:  func() { testAccPreCheckMePaymentMean(t) },
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/ovh/data_source_ovh_publiccloud_region_test.go
+++ b/ovh/data_source_ovh_publiccloud_region_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPublicCloudRegionDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckPublicCloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/data_source_ovh_publiccloud_regions_test.go
+++ b/ovh/data_source_ovh_publiccloud_regions_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPublicCloudRegionsDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckPublicCloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -34,61 +34,19 @@ func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
 }
 
-func testAccPreCheck(t *testing.T) {
-	v := os.Getenv("OVH_ENDPOINT")
-	if v == "" {
-		t.Fatal("OVH_ENDPOINT must be set for acceptance tests")
+func checkEnv(t *testing.T, e string) {
+	if os.Getenv(e) == "" {
+		t.Fatalf("%s must be set for acceptance tests", e)
 	}
+}
 
-	v = os.Getenv("OVH_APPLICATION_KEY")
-	if v == "" {
-		t.Fatal("OVH_APPLICATION_KEY must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_APPLICATION_SECRET")
-	if v == "" {
-		t.Fatal("OVH_APPLICATION_SECRET must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_CONSUMER_KEY")
-	if v == "" {
-		t.Fatal("OVH_CONSUMER_KEY must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_VRACK")
-	if v == "" {
-		t.Fatal("OVH_VRACK must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_PUBLIC_CLOUD")
-	if v == "" {
-		t.Fatal("OVH_PUBLIC_CLOUD must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_ZONE")
-	if v == "" {
-		t.Fatal("OVH_ZONE must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_IPLB_SERVICE")
-	if v == "" {
-		t.Fatal("OVH_IPLB_SERVICE must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_IP_BLOCK")
-	if v == "" {
-		t.Fatal("OVH_IP_BLOCK must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_IP")
-	if v == "" {
-		t.Fatal("OVH_IP must be set for acceptance tests")
-	}
-
-	v = os.Getenv("OVH_IP_REVERSE")
-	if v == "" {
-		t.Fatal("OVH_IP_REVERSE must be set for acceptance tests")
-	}
+// Checks that the environment variables needed to create the OVH API client
+// are set and create the client right away.
+func testAccPreCheckCredentials(t *testing.T) {
+	checkEnv(t, "OVH_ENDPOINT")
+	checkEnv(t, "OVH_APPLICATION_KEY")
+	checkEnv(t, "OVH_APPLICATION_SECRET")
+	checkEnv(t, "OVH_CONSUMER_KEY")
 
 	if testAccOVHClient == nil {
 		config := Config{
@@ -99,11 +57,55 @@ func testAccPreCheck(t *testing.T) {
 		}
 
 		if err := config.loadAndValidate(); err != nil {
-			t.Fatalf("couln't load OVH Client: %s", err)
+			t.Fatalf("Couldn't load OVH Client: %s", err)
 		} else {
 			testAccOVHClient = config.OVHClient
 		}
 	}
+}
+
+// Checks that the environment variables needed for the /ip acceptance tests
+// are set.
+func testAccPreCheckIp(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_IP")
+	checkEnv(t, "OVH_IP_BLOCK")
+	checkEnv(t, "OVH_IP_REVERSE")
+}
+
+// Checks that the environment variables needed for the /domain acceptance tests
+// are set.
+func testAccPreCheckDomain(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_ZONE")
+}
+
+// Checks that the environment variables needed for the /cloud acceptance tests
+// are set.
+func testAccPreCheckPublicCloud(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_PUBLIC_CLOUD")
+}
+
+// Checks that the environment variables needed for the /ipLoadbalacing acceptance tests
+// are set.
+func testAccPreCheckIpLoadbalancing(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_IPLB_SERVICE")
+}
+
+// Checks that the environment variables needed for the /vrack acceptance tests
+// are set.
+func testAccPreCheckVRack(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_VRACK")
+}
+
+// Checks that the environment variables needed for the /me/paymentMean acceptance tests
+// are set.
+func testAccPreCheckMePaymentMean(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnv(t, "OVH_TEST_BANKACCOUNT")
 }
 
 func testAccCheckVRackExists(t *testing.T) {

--- a/ovh/resource_ovh_domain_zone_record_test.go
+++ b/ovh/resource_ovh_domain_zone_record_test.go
@@ -98,7 +98,7 @@ func TestAccOvhDomainZoneRecord_Basic(t *testing.T) {
 	subdomain := acctest.RandomWithPrefix(test_prefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDomain(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{
@@ -126,7 +126,7 @@ func TestAccOvhDomainZoneRecord_Updated(t *testing.T) {
 	subdomain := acctest.RandomWithPrefix(test_prefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDomain(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{
@@ -198,7 +198,7 @@ func TestAccOvhDomainZoneRecord_updateType(t *testing.T) {
 	subdomain := acctest.RandomWithPrefix(test_prefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDomain(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{

--- a/ovh/resource_ovh_domain_zone_redirection_test.go
+++ b/ovh/resource_ovh_domain_zone_redirection_test.go
@@ -94,7 +94,7 @@ func TestAccOvhDomainZoneRedirection_Basic(t *testing.T) {
 	subdomain := acctest.RandomWithPrefix(test_prefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDomain(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRedirectionDestroy,
 		Steps: []resource.TestStep{
@@ -122,7 +122,7 @@ func TestAccOvhDomainZoneRedirection_Updated(t *testing.T) {
 	subdomain := acctest.RandomWithPrefix(test_prefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDomain(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRedirectionDestroy,
 		Steps: []resource.TestStep{

--- a/ovh/resource_ovh_ip_reverse_test.go
+++ b/ovh/resource_ovh_ip_reverse_test.go
@@ -17,13 +17,9 @@ resource "ovh_ip_reverse" "reverse" {
 }
 `, os.Getenv("OVH_IP_BLOCK"), os.Getenv("OVH_IP"), os.Getenv("OVH_IP_REVERSE"))
 
-func testAccCheckIpReversePreCheck(t *testing.T) {
-	testAccPreCheck(t)
-}
-
 func TestAccIpReverse_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccCheckIpReversePreCheck(t) },
+		PreCheck:     func() { testAccPreCheckIp(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIpReverseDestroy,
 		Steps: []resource.TestStep{

--- a/ovh/resource_ovh_iploadbalancing_http_farm_server_test.go
+++ b/ovh/resource_ovh_iploadbalancing_http_farm_server_test.go
@@ -237,6 +237,7 @@ func TestAccIpLoadbalancingHttpFarmServerBasicCreate(t *testing.T) {
 			steps = append(steps, w.TestStep(tcase))
 		}
 		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheckIpLoadbalancing(t) },
 			Providers:    testAccProviders,
 			CheckDestroy: w.TestDestroy,
 			Steps:        steps,

--- a/ovh/resource_ovh_iploadbalancing_http_farm_test.go
+++ b/ovh/resource_ovh_iploadbalancing_http_farm_test.go
@@ -78,6 +78,7 @@ func testAccIpLoadbalancingHttpFarmTestStep(name, zone string, port, probePort, 
 
 func TestAccIpLoadbalancingHttpFarmBasicCreate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckIpLoadbalancing(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIpLoadbalancingHttpFarmDestroy,
 		Steps: []resource.TestStep{

--- a/ovh/resource_ovh_iploadbalancing_http_route_rule_test.go
+++ b/ovh/resource_ovh_iploadbalancing_http_route_rule_test.go
@@ -62,7 +62,7 @@ func TestAccIPLoadbalancingRouteHTTPRuleBasicCreate(t *testing.T) {
 }
 
 func testAccCheckIpLoadbalancingRouteHTTPRulePreCheck(t *testing.T) {
-	testAccPreCheck(t)
+	testAccPreCheckIpLoadbalancing(t)
 	testAccCheckIpLoadbalancingExists(t)
 }
 

--- a/ovh/resource_ovh_iploadbalancing_http_route_test.go
+++ b/ovh/resource_ovh_iploadbalancing_http_route_test.go
@@ -57,7 +57,7 @@ func TestAccIPLoadbalancingRouteHTTPBasicCreate(t *testing.T) {
 }
 
 func testAccCheckIpLoadbalancingRouteHTTPPreCheck(t *testing.T) {
-	testAccPreCheck(t)
+	testAccPreCheckIpLoadbalancing(t)
 	testAccCheckIpLoadbalancingExists(t)
 }
 

--- a/ovh/resource_ovh_iploadbalancing_tcp_farm_server_test.go
+++ b/ovh/resource_ovh_iploadbalancing_tcp_farm_server_test.go
@@ -237,6 +237,7 @@ func TestAccIpLoadbalancingTcpFarmServerBasicCreate(t *testing.T) {
 			steps = append(steps, w.TestStep(tcase))
 		}
 		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheckIpLoadbalancing(t) },
 			Providers:    testAccProviders,
 			CheckDestroy: w.TestDestroy,
 			Steps:        steps,

--- a/ovh/resource_ovh_iploadbalancing_tcp_frontend_test.go
+++ b/ovh/resource_ovh_iploadbalancing_tcp_frontend_test.go
@@ -69,7 +69,7 @@ func TestAccOvhIpLoadbalancingTcpFrontend_basic(t *testing.T) {
 	iplb := os.Getenv("OVH_IPLB_SERVICE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIpLoadbalancing(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -110,7 +110,7 @@ func TestAccOvhIpLoadbalancingTcpFrontend_withfarm(t *testing.T) {
 	iplb := os.Getenv("OVH_IPLB_SERVICE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIpLoadbalancing(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/resource_ovh_publiccloud_private_network_subnet_test.go
+++ b/ovh/resource_ovh_publiccloud_private_network_subnet_test.go
@@ -59,7 +59,7 @@ func TestAccPublicCloudPrivateNetworkSubnet_basic(t *testing.T) {
 }
 
 func testAccCheckPublicCloudPrivateNetworkSubnetPreCheck(t *testing.T) {
-	testAccPreCheck(t)
+	testAccPreCheckPublicCloud(t)
 	testAccCheckPublicCloudExists(t)
 }
 

--- a/ovh/resource_ovh_publiccloud_private_network_test.go
+++ b/ovh/resource_ovh_publiccloud_private_network_test.go
@@ -121,7 +121,7 @@ func TestAccPublicCloudPrivateNetwork_basic(t *testing.T) {
 }
 
 func testAccCheckPublicCloudPrivateNetworkPreCheck(t *testing.T) {
-	testAccPreCheck(t)
+	testAccPreCheckPublicCloud(t)
 	testAccCheckPublicCloudExists(t)
 }
 

--- a/ovh/resource_ovh_publiccloud_user_test.go
+++ b/ovh/resource_ovh_publiccloud_user_test.go
@@ -18,7 +18,7 @@ resource "ovh_publiccloud_user" "user" {
 
 func TestAccPublicCloudUser_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccCheckPublicCloudUserPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckPublicCloud(t); testAccCheckPublicCloudExists(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPublicCloudUserDestroy,
 		Steps: []resource.TestStep{
@@ -31,11 +31,6 @@ func TestAccPublicCloudUser_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckPublicCloudUserPreCheck(t *testing.T) {
-	testAccPreCheck(t)
-	testAccCheckPublicCloudExists(t)
 }
 
 func testAccCheckPublicCloudUserExists(n string, t *testing.T) resource.TestCheckFunc {

--- a/ovh/resource_ovh_vrack_publiccloud_attachment_test.go
+++ b/ovh/resource_ovh_vrack_publiccloud_attachment_test.go
@@ -33,7 +33,7 @@ func TestAccVRackPublicCloudAttachment_basic(t *testing.T) {
 }
 
 func testAccCheckVRackPublicCloudAttachmentPreCheck(t *testing.T) {
-	testAccPreCheck(t)
+	testAccPreCheckVRack(t)
 	testAccCheckVRackExists(t)
 	testAccCheckPublicCloudExists(t)
 }


### PR DESCRIPTION
In order to more easily run tests selectively, I split all the pre check
tests. This way you don't need all the OVH_* env variables when testing
only a part of the provider.