### PR TITLE
Add "ovh_iploadbalancing_refresh" to the website sidebar

### DIFF
--- a/website/ovh.erb
+++ b/website/ovh.erb
@@ -113,6 +113,9 @@
                 <li<%= sidebar_current("docs-ovh-resource-iploadbalancing-http-route-rule") %>>
                     <a href="/docs/providers/ovh/r/iploadbalancing_http_route_rule.html">ovh_iploadbalancing_http_route_rule</a>
                 </li>
+                <li<%= sidebar_current("docs-ovh-resource-iploadbalancing-refresh") %>>
+                    <a href="/docs/providers/ovh/r/iploadbalancing_refresh.html">ovh_iploadbalancing_refresh</a>
+                </li>
             </ul>
         </li>
 


### PR DESCRIPTION
The documentation page for `ovh_iploadbalancing_refresh` exists but is not linked in the sidebar. 