### PR TITLE
handle record id bigger than 32bits

### DIFF
--- a/ovh/resource_ovh_domain_zone_record.go
+++ b/ovh/resource_ovh_domain_zone_record.go
@@ -14,7 +14,7 @@ import (
 )
 
 type OvhDomainZoneRecord struct {
-	Id        int    `json:"id,omitempty"`
+	Id        int64  `json:"id,omitempty"`
 	Zone      string `json:"zone,omitempty"`
 	Target    string `json:"target"`
 	Ttl       int    `json:"ttl,omitempty"`
@@ -144,7 +144,7 @@ func resourceOvhDomainZoneRecordCreate(d *schema.ResourceData, meta interface{})
 
 	}
 
-	d.SetId(strconv.Itoa(resultRecord.Id))
+	d.SetId(strconv.FormatInt(resultRecord.Id, 10))
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
 		log.Printf("[WARN] OVH Domain zone refresh after record creation failed: %s", err)

--- a/ovh/resource_ovh_domain_zone_record_test.go
+++ b/ovh/resource_ovh_domain_zone_record_test.go
@@ -285,7 +285,7 @@ func testAccCheckOvhDomainZoneRecordExists(n string, record *OvhDomainZoneRecord
 			return err
 		}
 
-		if strconv.Itoa(record.Id) != rs.Primary.ID {
+		if strconv.FormatInt(record.Id, 10) != rs.Primary.ID {
 			return fmt.Errorf("Record not found")
 		}
 


### PR DESCRIPTION
The OvhDomainZoneRecordImportState can have an Id bigger than 32 bits.
I did this temporary fix for my own use, and created the pull request to open the conversation.

I'm not a Go developer and just made this to continue working.