### PR TITLE
r/cloud_network_private/subnet: fix acctest & rework

### DIFF
--- a/ovh/resource_ovh_publiccloud_private_network_subnet_test.go
+++ b/ovh/resource_ovh_publiccloud_private_network_subnet_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var testAccPublicCloudPrivateNetworkSubnetConfig = fmt.Sprintf(`
+var testAccPublicCloudPrivateNetworkSubnetConfig_attachVrack = `
 resource "ovh_vrack_cloudproject" "attach" {
   vrack_id   = "%s"
   project_id = "%s"
@@ -17,10 +16,24 @@ resource "ovh_vrack_cloudproject" "attach" {
 
 data "ovh_cloud_regions" "regions" {
   project_id = ovh_vrack_cloudproject.attach.project_id
+
+  has_services_up = ["network"]
 }
+`
+
+var testAccPublicCloudPrivateNetworkSubnetConfig_noAttachVrack = `
+data "ovh_cloud_regions" "regions" {
+  project_id = "%s"
+
+  has_services_up = ["network"]
+}
+`
+
+var testAccPublicCloudPrivateNetworkSubnetConfig_basic = `
+%s
 
 resource "ovh_cloud_network_private" "network" {
-  project_id = ovh_vrack_cloudproject.attach.project_id
+  project_id = data.ovh_cloud_regions.regions.project_id
   vlan_id    = 0
   name       = "terraform_testacc_private_net"
   regions    = tolist(data.ovh_cloud_regions.regions.names)
@@ -38,20 +51,45 @@ resource "ovh_cloud_network_private_subnet" "subnet" {
   dhcp       = true
   no_gateway = false
 }
-`, os.Getenv("OVH_VRACK"), os.Getenv("OVH_PUBLIC_CLOUD"))
+`
+
+func testAccPublicCloudPrivateNetworkSubnetConfig() string {
+	attachVrack := fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkSubnetConfig_attachVrack,
+		os.Getenv("OVH_VRACK"),
+		os.Getenv("OVH_PUBLIC_CLOUD"),
+	)
+	noAttachVrack := fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkSubnetConfig_noAttachVrack,
+		os.Getenv("OVH_PUBLIC_CLOUD"),
+	)
+
+	if os.Getenv("OVH_ATTACH_VRACK") == "0" {
+		return fmt.Sprintf(
+			testAccPublicCloudPrivateNetworkSubnetConfig_basic,
+			noAttachVrack,
+		)
+	}
+
+	return fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkSubnetConfig_basic,
+		attachVrack,
+	)
+}
 
 func TestAccPublicCloudPrivateNetworkSubnet_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccCheckPublicCloudPrivateNetworkSubnetPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPublicCloudPrivateNetworkSubnetDestroy,
+		PreCheck:  func() { testAccCheckPublicCloudPrivateNetworkSubnetPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicCloudPrivateNetworkSubnetConfig,
+				Config: testAccPublicCloudPrivateNetworkSubnetConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVRackPublicCloudAttachmentExists("ovh_vrack_cloudproject.attach", t),
-					testAccCheckPublicCloudPrivateNetworkExists("ovh_cloud_network_private.network", t),
-					testAccCheckPublicCloudPrivateNetworkSubnetExists("ovh_cloud_network_private_subnet.subnet", t),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_subnet.subnet", "project_id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_subnet.subnet", "network_id"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_subnet.subnet", "start", "192.168.168.100"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_subnet.subnet", "end", "192.168.168.200"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_subnet.subnet", "network", "192.168.168.0/24"),
 				),
 			},
 		},
@@ -61,56 +99,5 @@ func TestAccPublicCloudPrivateNetworkSubnet_basic(t *testing.T) {
 func testAccCheckPublicCloudPrivateNetworkSubnetPreCheck(t *testing.T) {
 	testAccPreCheckPublicCloud(t)
 	testAccCheckPublicCloudExists(t)
-}
-
-func testAccCheckPublicCloudPrivateNetworkSubnetExists(n string, t *testing.T) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*Config)
-
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if rs.Primary.Attributes["project_id"] == "" {
-			return fmt.Errorf("No Project ID is set")
-		}
-
-		if rs.Primary.Attributes["network_id"] == "" {
-			return fmt.Errorf("No Network ID is set")
-		}
-
-		return publicCloudPrivateNetworkSubnetExists(
-			rs.Primary.Attributes["project_id"],
-			rs.Primary.Attributes["network_id"],
-			rs.Primary.ID,
-			config.OVHClient,
-		)
-	}
-}
-
-func testAccCheckPublicCloudPrivateNetworkSubnetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ovh_cloud_network_private_subnet" {
-			continue
-		}
-
-		err := publicCloudPrivateNetworkSubnetExists(
-			rs.Primary.Attributes["project_id"],
-			rs.Primary.Attributes["network_id"],
-			rs.Primary.ID,
-			config.OVHClient,
-		)
-
-		if err == nil {
-			return fmt.Errorf("VRack > Public Cloud Private Network Subnet still exists")
-		}
-
-	}
-	return nil
+	testAccPreCheckVRack(t)
 }

--- a/ovh/resource_ovh_publiccloud_private_network_test.go
+++ b/ovh/resource_ovh_publiccloud_private_network_test.go
@@ -9,10 +9,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var testAccPublicCloudPrivateNetworkConfig = fmt.Sprintf(`
+var testAccPublicCloudPrivateNetworkConfig_attachVrack = `
 resource "ovh_vrack_cloudproject" "attach" {
   vrack_id   = "%s"
   project_id = "%s"
@@ -20,16 +19,53 @@ resource "ovh_vrack_cloudproject" "attach" {
 
 data "ovh_cloud_regions" "regions" {
   project_id = ovh_vrack_cloudproject.attach.project_id
+
+  has_services_up = ["network"]
 }
+`
+
+var testAccPublicCloudPrivateNetworkConfig_noAttachVrack = `
+data "ovh_cloud_regions" "regions" {
+  project_id = "%s"
+
+  has_services_up = ["network"]
+}
+`
+
+var testAccPublicCloudPrivateNetworkConfig_basic = `
+%s
 
 resource "ovh_cloud_network_private" "network" {
-  project_id = ovh_vrack_cloudproject.attach.project_id
+  project_id = data.ovh_cloud_regions.regions.project_id
   vlan_id    = 0
   name       = "terraform_testacc_private_net"
   regions    = tolist(data.ovh_cloud_regions.regions.names)
 }
+`
 
-`, os.Getenv("OVH_VRACK"), os.Getenv("OVH_PUBLIC_CLOUD"))
+func testAccPublicCloudPrivateNetworkConfig() string {
+	attachVrack := fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkConfig_attachVrack,
+		os.Getenv("OVH_VRACK"),
+		os.Getenv("OVH_PUBLIC_CLOUD"),
+	)
+	noAttachVrack := fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkConfig_noAttachVrack,
+		os.Getenv("OVH_PUBLIC_CLOUD"),
+	)
+
+	if os.Getenv("OVH_ATTACH_VRACK") == "0" {
+		return fmt.Sprintf(
+			testAccPublicCloudPrivateNetworkConfig_basic,
+			noAttachVrack,
+		)
+	}
+
+	return fmt.Sprintf(
+		testAccPublicCloudPrivateNetworkConfig_basic,
+		attachVrack,
+	)
+}
 
 func init() {
 	resource.AddTestSweepers("ovh_cloud_network_private", &resource.Sweeper{
@@ -105,15 +141,15 @@ func testSweepCloudNetworkPrivate(region string) error {
 
 func TestAccPublicCloudPrivateNetwork_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccCheckPublicCloudPrivateNetworkPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPublicCloudPrivateNetworkDestroy,
+		PreCheck:  func() { testAccCheckPublicCloudPrivateNetworkPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicCloudPrivateNetworkConfig,
+				Config: testAccPublicCloudPrivateNetworkConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVRackPublicCloudAttachmentExists("ovh_vrack_cloudproject.attach", t),
-					testAccCheckPublicCloudPrivateNetworkExists("ovh_cloud_network_private.network", t),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private.network", "project_id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private.network", "id"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private.network", "vlan_id", "0"),
 				),
 			},
 		},
@@ -123,41 +159,5 @@ func TestAccPublicCloudPrivateNetwork_basic(t *testing.T) {
 func testAccCheckPublicCloudPrivateNetworkPreCheck(t *testing.T) {
 	testAccPreCheckPublicCloud(t)
 	testAccCheckPublicCloudExists(t)
-}
-
-func testAccCheckPublicCloudPrivateNetworkExists(n string, t *testing.T) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*Config)
-
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if rs.Primary.Attributes["project_id"] == "" {
-			return fmt.Errorf("No Project ID is set")
-		}
-
-		return publicCloudPrivateNetworkExists(rs.Primary.Attributes["project_id"], rs.Primary.ID, config.OVHClient)
-	}
-}
-
-func testAccCheckPublicCloudPrivateNetworkDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ovh_cloud_network_private" {
-			continue
-		}
-
-		err := publicCloudPrivateNetworkExists(rs.Primary.Attributes["project_id"], rs.Primary.ID, config.OVHClient)
-		if err == nil {
-			return fmt.Errorf("VRack > Public Cloud Private Network still exists")
-		}
-
-	}
-	return nil
+	testAccPreCheckVRack(t)
 }


### PR DESCRIPTION
- fix acctest: since new global regions are returned
  by the ovh_cloud_regions datasource, filter regions
  with network service UP
- use OVH_ATTACH_VRACK=0 env var to disable vrack_attach
  (useful when running tests against a project already
  attachted to a project)
- rework test with more terraform-sdk test helper funcs