### PR TITLE
Add a datasource for vps (on the dedicated_server model)

### DIFF
--- a/ovh/data_source_ovh_vps.go
+++ b/ovh/data_source_ovh_vps.go
@@ -1,0 +1,168 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceVPS() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVPSRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Here come all the computed items
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"displayname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"netbootmode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"slamonitoring": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"keymap": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vcore": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"offertype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"model": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"offer": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"ips": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"datacenter": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"longname": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVPSRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	vps := &VPS{}
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/vps/%s",
+			url.PathEscape(serviceName),
+		),
+		&vps,
+	)
+
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(vps.Name)
+	d.Set("name", vps.Name)
+	d.Set("zone", vps.Zone)
+	d.Set("state", vps.State)
+	d.Set("vcore", vps.Vcore)
+	d.Set("cluster", vps.Cluster)
+	d.Set("memory", vps.Memory)
+	d.Set("netbootmode", vps.NetbootMode)
+	d.Set("keymap", vps.Keymap)
+	d.Set("offertype", vps.OfferType)
+	d.Set("slamonitoring", vps.SlaMonitorting)
+	d.Set("displayname", vps.DisplayName)
+	var model = make(map[string]string)
+	model["name"] = vps.Model.Name
+	model["offer"] = vps.Model.Offer
+	model["version"] = vps.Model.Version
+	d.Set("model", model)
+	d.Set("type", ovhvps_getType(vps.OfferType, vps.Model.Name, vps.Model.Version))
+
+	ips := []string{}
+	err = config.OVHClient.Get(
+		fmt.Sprintf("/vps/%s/ips", d.Id()),
+		&ips,
+	)
+
+	d.Set("ips", ips)
+
+	vpsDatacenter := VPSDatacenter{}
+	err = config.OVHClient.Get(
+		fmt.Sprintf("/vps/%s/datacenter", d.Id()),
+		&vpsDatacenter,
+	)
+	datacenter := make(map[string]string)
+	datacenter["name"] = vpsDatacenter.Name
+	datacenter["longname"] = vpsDatacenter.Longname
+	d.Set("datacenter", datacenter)
+	return nil
+}

--- a/ovh/data_source_ovh_vps_test.go
+++ b/ovh/data_source_ovh_vps_test.go
@@ -1,0 +1,36 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccVPSDataSource_basic(t *testing.T) {
+	vps := os.Getenv("OVH_VPS")
+	config := fmt.Sprintf(testAccVPSDatasourceConfig_Basic, vps)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckVPS(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_vps.server", "name", vps),
+					resource.TestCheckResourceAttr(
+						"data.ovh_vps.server", "service_name", vps),
+				),
+			},
+		},
+	})
+}
+
+const testAccVPSDatasourceConfig_Basic = `
+data "ovh_vps" "server" {
+  service_name  = "%s"
+}
+`

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 			"ovh_me_paymentmean_creditcard":        dataSourceMePaymentmeanCreditcard(),
 			"ovh_me_ssh_key":                       dataSourceMeSshKey(),
 			"ovh_me_ssh_keys":                      dataSourceMeSshKeys(),
+			"ovh_vps":                              dataSourceVPS(),
 			"ovh_vracks":                           dataSourceVracks(),
 
 			// Legacy naming schema (publiccloud)

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -119,6 +119,11 @@ func testAccPreCheckDedicatedServer(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_DEDICATED_SERVER")
 }
 
+func testAccPreCheckVPS(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_VPS")
+}
+
 func testAccCheckVRackExists(t *testing.T) {
 	type vrackResponse struct {
 		Name        string `json:"name"`

--- a/ovh/types_vps.go
+++ b/ovh/types_vps.go
@@ -1,0 +1,56 @@
+package ovh
+
+import (
+	"fmt"
+)
+
+type VPSModel struct {
+	Name    string `json:"name"`
+	Offer   string `json:"offer"`
+	Memory  int    `json:"memory"`
+	Vcore   int    `json:"vcore"`
+	Version string `json:"version"`
+	Disk    int    `json:"disk"`
+}
+
+type VPS struct {
+	Name           string   `json:"name"`
+	Cluster        string   `json:"cluster"`
+	Memory         int      `json:"memoryLimit"`
+	NetbootMode    string   `json:"netbootMode"`
+	Keymap         string   `json:"keymap"`
+	Zone           string   `json:"zone"`
+	State          string   `json:"state"`
+	Vcore          int      `json:"vcore"`
+	OfferType      string   `json:"offerType"`
+	SlaMonitorting bool     `json:"slaMonitoring"`
+	DisplayName    string   `json:"displayName"`
+	Model          VPSModel `json:"model"`
+}
+
+type VPSDatacenter struct {
+	Name     string `json:"name"`
+	Longname string `json:"longname"`
+}
+
+type VPSProperties struct {
+	NetbootMode    *string `json:"netbootMode"`
+	Keymap         *string `json:"keymap"`
+	SlaMonitorting bool    `json:"slaMonitoring"`
+	DisplayName    *string `json:"displayName"`
+}
+
+func ovhvps_getType(offertype string, model_name string, model_version string) string {
+	var offertypeToOfferPrefix = make(map[string]string)
+	offertypeToOfferPrefix["cloud"] = "ceph-nvme"
+	offertypeToOfferPrefix["cloud-ram"] = "ceph-nvme-ram"
+	offertypeToOfferPrefix["ssd"] = "ssd"
+	offertypeToOfferPrefix["classic"] = "classic"
+	return (fmt.Sprintf("vps_%s_%s_%s", offertypeToOfferPrefix[offertype],
+		model_name,
+		model_version))
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/website/docs/d/vps.html.markdown
+++ b/website/docs/d/vps.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "ovh"
+page_title: "OVH: vps"
+sidebar_current: "docs-ovh-datasource-vps-x"
+description: |-
+  Get information of a vps associatd with your OVJ Account
+---
+
+# ovh\_vps
+
+Use this data source to retrieve information about a vps associated with 
+your OVH Account.
+
+## Example Usage
+
+```hcl
+data "ovh_vps" "server" {
+   service_name = "XXXXXX"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The service_name of your dedicated server.
+
+## Attribute Reference
+
+`id` is set with the service\_name of the vps name (ex: "vps-123456.ovh.net")
+
+In addition, the following attributes are exported:
+
+* `cluster` - The ovh cluster the vps is in
+* `datacenter` - The datacenter in which the vps is located
+  * `datacenter.longname` - The fullname of the datacenter (ex: "Strasbourg SBG1")
+  * `datacenter.name` - The short name of the datacenter (ex: "sbg1)
+* `displayname` - The displayed name in the ovh web admin
+* `ips` - The list of IPs addresses attached to the vps
+* `keymap` - The keymap for the ip kvm, valid values "", "fr", "us"
+* `memory` - The amount of memory in MB of the vps. 
+* `model` - A dict describing the type of vps.
+* `model.name` - The model name (ex: model1)
+* `model.offer` - The model human description (ex: "VPS 2016 SSD 1")
+* `model.version` - The model version (ex: "2017v2")
+* `netbootmode` - The source of the boot kernel
+* `offertype` - The type of offer (ssd, cloud, classic)
+* `slamonitoring` - A boolean to indicate if OVH sla monitoring is active.
+* `state` -  The state of the vps
+* `type` - The type of server
+* `vcore` - The number of vcore of the vps
+* `zone` - The OVH zone where the vps is


### PR DESCRIPTION
This is the first step to have feature parity between vps and dedicated servers.
