### PR TITLE
add cookie to http farm stickiness

### DIFF
--- a/ovh/resource_ovh_iploadbalancing_http_farm.go
+++ b/ovh/resource_ovh_iploadbalancing_http_farm.go
@@ -46,7 +46,7 @@ func resourceIpLoadbalancingHttpFarm() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					err := validateStringEnum(v.(string), []string{"sourceIp"})
+					err := validateStringEnum(v.(string), []string{"sourceIp", "cookie"})
 					if err != nil {
 						errors = append(errors, err)
 					}

--- a/website/docs/r/iploadbalancing_http_farm.markdown
+++ b/website/docs/r/iploadbalancing_http_farm.markdown
@@ -15,7 +15,7 @@ Creates a http backend server group (farm) to be used by loadbalancing frontend(
 ```
 data "ovh_iploadbalancing" "lb" {
   service_name = "ip-1.2.3.4"
-   state       = "ok"  
+   state       = "ok"
 }
 
 resource "ovh_iploadbalancing_http_farm" "farmname" {
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `balance` - Load balancing algorithm. `roundrobin` if null (`first`, `leastconn`, `roundrobin`, `source`)
 * `display_name` - Readable label for loadbalancer farm
 * `port` - Port attached to your farm ([1..49151]). Inherited from frontend if null
-* `stickiness` - 	Stickiness type. No stickiness if null (`sourceIp`)
+* `stickiness` - 	Stickiness type. No stickiness if null (`sourceIp`, `cookie`)
 * `vrack_network_id` - Internal Load Balancer identifier of the vRack private network to attach to your farm, mandatory when your Load Balancer is attached to a vRack
 * `zone` - (Required) Zone where the farm will be defined (ie. `GRA`, `BHS` also supports `ALL`)
 * `probe` - define a backend healthcheck probe


### PR DESCRIPTION
Control value for stickiness on the ressource ovh_iploadbalancing_http_farm doesn't allow to use cookie.